### PR TITLE
Fix #43

### DIFF
--- a/src/components/NewsEntry.astro
+++ b/src/components/NewsEntry.astro
@@ -35,7 +35,9 @@ const newsId = slug.replace(regex, "");
 
 <section id={newsId}>
   <h2>{entry?.data.title}</h2>
-  <span class="published-at">{dayjs(entry?.data.publishedAt).tz().format("LLL")}</span>
+  <time class="published-at" datetime={dayjs(entry?.data.publishedAt).tz().format("YYYY-MM-DDTHH:mmZ")}
+    >{dayjs(entry?.data.publishedAt).tz().format("LLL")}</time
+  >
   <div class="markdown-body">
     <Content />
   </div>


### PR DESCRIPTION
Close: #43 

datetime属性にはタイムゾーン付きのISO8601文字列(YYYY-MM-DDTHH:mm±HH:mm)を渡すことにした。ちゃんと有効で、Living StandardのExampleにも同様の形式の例がある。

https://html.spec.whatwg.org/multipage/text-level-semantics.html#attr-time-datetime
