### PR TITLE
sp向けレイアウトのときHeaderのaタグに `display:block;`を指定

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -213,6 +213,7 @@ const links: HeaderLink[] = [
             }
           }
           @media screen and ($sp-query) {
+            display: block;
             transition: color 0.25s ease;
             &:hover {
               color: $blue;

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -213,7 +213,6 @@ const links: HeaderLink[] = [
             }
           }
           @media screen and ($sp-query) {
-            display: block;
             transition: color 0.25s ease;
             &:hover {
               color: $blue;
@@ -314,10 +313,14 @@ const links: HeaderLink[] = [
       margin: 0;
       a {
         position: relative;
-        display: inline-block;
         font-size: 1rem;
         padding: 1em 0;
         text-decoration: none;
+
+        display: inline-block;
+        @media screen and ($sp-query) {
+          display: block;
+        }
       }
     }
     &[aria-hidden="true"] {


### PR DESCRIPTION
https://github.com/sohosai/teaser23/pull/67#discussion_r1412736546

こうしないとタップできる枠が要素いっぱいに広がらないようです。