### PR TITLE
Twitter向けOGタグを整理

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -64,10 +64,6 @@ const title = pageName ? `${pageName(currentLocale)} - ${t("base.サイト名")}
 }
 <meta property="og:image" content={new URL(ogpImage.src, Astro.site)} />
 <meta property="og:image:alt" content={ogpImage.alt} />
+
 <meta name="twitter:card" content="summary_large_image" />
-<meta name="twitter:url" content={Astro.url} />
-<meta name="twitter:title" content={description} />
 <meta name="twitter:site" content={TWITTER_ID} />
-<meta name="twitter:description" content={t("base.サイト説明文")} />
-<meta name="twitter:image" content={new URL(ogpImage.src, Astro.site)} />
-<meta name="twitter:image:alt" content={ogpImage.alt} />

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -67,3 +67,4 @@ const title = pageName ? `${pageName(currentLocale)} - ${t("base.サイト名")}
 
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:site" content={TWITTER_ID} />
+<meta name="twitter:creator" content={TWITTER_ID} />


### PR DESCRIPTION
https://github.com/sohosai/teaser23/pull/67#discussion_r1413079218

[カードの利用開始 | Docs | Twitter Developer Platform](https://developer.twitter.com/ja/docs/tweets/optimize-with-cards/guides/getting-started)の「TwitterカードとOpen Graph」の項にある例を見ると、`twitter:image`、`twitter:title`、`twitter:url`は不要で、通常のOGを設定するだけで十分っぽいので修正。

また、`twitter:creator`を追加。